### PR TITLE
Feat/#21 restructure resources

### DIFF
--- a/Assets/GUI/HitIndicator/Scripts/TextManager.cs
+++ b/Assets/GUI/HitIndicator/Scripts/TextManager.cs
@@ -20,14 +20,14 @@ public class TextManager : MonoBehaviour
     ///</summary>
     static TextManager()
     {
-        GameObject screen_canvas = Resources.Load<GameObject>("ScreenCanvas");
+        GameObject screen_canvas = PrefabRepository.instance.TextManagerScreenCanvas;
         if (screen_canvas == null)
         {
             Debug.LogError("Could not load canvas resources");
         }
         m_screen_canvas = Instantiate(screen_canvas);
 
-        m_damage_text = Resources.Load<APopupText>("DamageTextParent");
+        m_damage_text = PrefabRepository.instance.DamageTextParent;
         if (m_damage_text == null)
         {
             Debug.LogError("Could not load damage text prefab");
@@ -55,7 +55,7 @@ public class TextManager : MonoBehaviour
         screen = Camera.main.WorldToScreenPoint(new Vector2(transform.position.x + pad_x, transform.position.y + pad_y));
 
         if (!m_screen_canvas) {
-            GameObject screen_canvas = Resources.Load<GameObject>("ScreenCanvas");
+            GameObject screen_canvas = PrefabRepository.instance.TextManagerScreenCanvas;
             m_screen_canvas = Instantiate(screen_canvas);
         }
 

--- a/Assets/Managers/IndividualManagers.meta
+++ b/Assets/Managers/IndividualManagers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 284327ed380759f4f8a6654c141b6933
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Managers/IndividualManagers/PrefabRepository.prefab
+++ b/Assets/Managers/IndividualManagers/PrefabRepository.prefab
@@ -1,0 +1,53 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1896254453353552}
+  m_IsPrefabParent: 1
+--- !u!1 &1896254453353552
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4547849908401444}
+  - component: {fileID: 114683810016409590}
+  m_Layer: 0
+  m_Name: PrefabRepository
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4547849908401444
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1896254453353552}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114683810016409590
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1896254453353552}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e0dd250e69fdfdf4b9d8e1981705b007, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Managers/IndividualManagers/PrefabRepository.prefab.meta
+++ b/Assets/Managers/IndividualManagers/PrefabRepository.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 11eae0654545e864f8dda29b70e23e95
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Managers/ManagerManager.prefab
+++ b/Assets/Managers/ManagerManager.prefab
@@ -147,6 +147,22 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 0
+--- !u!1 &1613790751223570
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4033324191849536}
+  - component: {fileID: 114340479095284318}
+  m_Layer: 0
+  m_Name: PrefabRepository
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!1 &1926877952403620
 GameObject:
   m_ObjectHideFlags: 1
@@ -165,6 +181,19 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!4 &4033324191849536
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1613790751223570}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 5.100374, y: 3.077394, z: 0.06934808}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4476523195268790}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4070550334566280
 Transform:
   m_ObjectHideFlags: 1
@@ -198,13 +227,14 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1542695210757896}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.036231905, y: -0.7324435, z: -0.06934808}
+  m_LocalPosition: {x: -5.100374, y: -3.077394, z: -0.06934808}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4944519439596492}
   - {fileID: 224725883365613840}
   - {fileID: 4442285878304740}
   - {fileID: 4070550334566280}
+  - {fileID: 4033324191849536}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -485,6 +515,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 65137e7f9ac56ce45b4742dcd24d9b08, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114340479095284318
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1613790751223570}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e0dd250e69fdfdf4b9d8e1981705b007, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &114388710003965838

--- a/Assets/Managers/PrefabRepository.cs
+++ b/Assets/Managers/PrefabRepository.cs
@@ -1,0 +1,87 @@
+﻿using UnityEngine;
+using System.Collections;
+using System.Collections.Generic;
+
+public class PrefabRepository : MonoBehaviour
+{
+    public float LoadingProgressPercentage { get; internal set; }
+    private readonly int _loadingCategories = 5;
+    private int _internalProgress = 0;
+
+    public static PrefabRepository instance = null;
+
+    public GameObject TextManagerScreenCanvas { get; private set; }
+    public APopupText DamageTextParent { get; private set; }
+    public GameObject Player { get; private set; }
+    public GameObject[] AllRegularRooms { get; private set; }
+    public GameObject[] AllBossRooms { get; private set; }
+    public GameObject[] AllPowerups { get; private set; }
+    public GameObject EnemySpawnerBullet { get; private set; }
+    public GameObject Bullet { get; private set; }
+    public GameObject ImmolationBullet { get; private set; }
+    public GameObject MeleeBullet { get; private set; }
+    public GameObject PlayerMeleeBullet { get; private set; }
+    public GameObject ShieldBullet { get; private set; }
+    public GameObject SpecialBullet { get; private set; }
+    public readonly List<AudioClip[]> Songs = new List<AudioClip[]>();
+    public readonly List<AudioClip> Sounds = new List<AudioClip>();
+
+    private void Awake()
+    {
+        if (instance == null)
+            instance = this;
+        else
+            Destroy(gameObject);
+
+
+        // Text manager
+        TextManagerScreenCanvas = Resources.Load<GameObject>("ScreenCanvas");
+        DamageTextParent = Resources.Load<APopupText>("DamageTextParent");
+        IncrementProgress();
+
+        // Room generation
+        AllRegularRooms = Resources.LoadAll<GameObject>("Regular");
+        AllBossRooms = Resources.LoadAll<GameObject>("Boss");
+        IncrementProgress();
+
+        // Bullets
+        EnemySpawnerBullet = Resources.Load<GameObject>("EnemySpawnerBullet");
+        Bullet = Resources.Load<GameObject>("Bullet");
+        ImmolationBullet = Resources.Load<GameObject>("ImmolationBullet");
+        MeleeBullet = Resources.Load<GameObject>("MeleeBullet");
+        PlayerMeleeBullet = Resources.Load<GameObject>("PlayerMeleeBullet");
+        ShieldBullet = Resources.Load<GameObject>("ShieldBullet");
+        SpecialBullet = Resources.Load<GameObject>("SpecialBullet");
+        IncrementProgress();
+
+        // Audio
+        string[] songsToLoad = { "overworld", "spooky", "fight" };
+        foreach (string song in songsToLoad)
+        {
+            Songs.Add(
+                new AudioClip[] {
+                    (Resources.Load(song + "-1") as AudioClip),
+                    (Resources.Load(song + "-2") as AudioClip)
+                    });
+        }
+        string[] soundsToLoad = {"crash1", "crash2", "crash3", "crash4",
+                                "plopp1", "plopp2", "mouth1-1", "mouth2-1",
+                                "mouth3-1", "mouth4-1", "mouth5-1", "tssss1",
+                                "tssss2", "pew1", "shield", "swish1"};
+        foreach (string sound in soundsToLoad)
+        {
+            Sounds.Add(Resources.Load(sound) as AudioClip);
+        }
+        IncrementProgress();
+
+        // Misc
+        Player = Resources.Load<GameObject>("Player3D");
+        AllPowerups = Resources.LoadAll<GameObject>("powerups");
+        IncrementProgress();
+    }
+
+    private void IncrementProgress()
+    {
+        LoadingProgressPercentage = ++_internalProgress / _loadingCategories;
+    }
+}

--- a/Assets/Managers/PrefabRepository.cs.meta
+++ b/Assets/Managers/PrefabRepository.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e0dd250e69fdfdf4b9d8e1981705b007
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Menu/Scripts/ClassSelectScript.cs
+++ b/Assets/Menu/Scripts/ClassSelectScript.cs
@@ -79,7 +79,7 @@ public class ClassSelectScript : MonoBehaviour {
                         PlayerManager.playersReady += 1;
 
                         //Instantiate Player
-                        GameObject player = Resources.Load<GameObject>("Player3D");
+                        GameObject player = PrefabRepository.instance.Player;
                         players[playerID] = Instantiate(player, spawner.spawners[playerID].transform.position, player.transform.rotation);
                         PlayerManager.PlayerObjects.Add(players[playerID]);
 

--- a/Assets/Rooms/Scripts/RoomSpawner.cs
+++ b/Assets/Rooms/Scripts/RoomSpawner.cs
@@ -18,8 +18,8 @@ public class RoomSpawner : MonoBehaviour {
 
 		rooms = new GameObject[nTiles, nTiles];
 
-		// Fetch all room prefabs
-		Object[] subListObjects = Resources.LoadAll("Regular", typeof(GameObject));
+        // Fetch all room prefabs
+        Object[] subListObjects = PrefabRepository.instance.AllRegularRooms;
 		foreach (GameObject subListObject in subListObjects) {
 			GameObject lo = (GameObject)subListObject;
 			roomList.Add(lo);
@@ -29,8 +29,8 @@ public class RoomSpawner : MonoBehaviour {
 		GameObject spawn = GameObject.Find("PlayerSpawner");
 		spawn.transform.position = spawnPos;
 
-		// Instantiate rooms
-		Object[] bossRooms = Resources.LoadAll("Boss", typeof(GameObject));
+        // Instantiate rooms
+        Object[] bossRooms = PrefabRepository.instance.AllBossRooms;
 		GameObject bossRoom = (GameObject) bossRooms[0];
 		rooms[(nTiles - 1) / 2, (nTiles - 1) / 2] = Object.Instantiate(bossRoom, Vector3.zero, Quaternion.identity, transform);
 		rooms[(nTiles - 1) / 2, (nTiles - 1) / 2].transform.localScale = new Vector3(scale, scale, 1f);

--- a/Assets/Sounds/Scripts/SoundManager.cs
+++ b/Assets/Sounds/Scripts/SoundManager.cs
@@ -7,14 +7,11 @@ public class SoundManager : MonoBehaviour {
 	public AudioSource music;
 	public static SoundManager instance = null;
 	private AudioClip musicLoop;
-	private string[] songsToLoad = {"overworld", "spooky", "fight"};
-	private List<AudioClip[]> songs = new List<AudioClip[]>();
-	private string[] soundsToLoad = {"crash1", "crash2", "crash3", "crash4",
-									"plopp1", "plopp2", "mouth1-1", "mouth2-1", 
-									"mouth3-1", "mouth4-1", "mouth5-1", "tssss1", 
-									"tssss2", "pew1", "shield", "swish1"};
-	private List<AudioClip> sounds = new List<AudioClip>();
-	private int currentTrack = 0;
+
+    private List<AudioClip[]> songs;
+    private List<AudioClip> sounds;
+
+    private int currentTrack = 0;
 
 	// Use this for initialization
 	void Awake () {
@@ -23,20 +20,8 @@ public class SoundManager : MonoBehaviour {
 		} else if (instance != null) {
 			Destroy(gameObject);
 		}
-
-
-
-		foreach (string song in songsToLoad) {
-			songs.Add(
-				new AudioClip[] {
-					(Resources.Load(song + "-1") as AudioClip), 
-					(Resources.Load(song + "-2") as AudioClip)
-					});
-		}
-
-		foreach (string sound in soundsToLoad) {
-			sounds.Add(Resources.Load(sound) as AudioClip);
-		}
+        songs = PrefabRepository.instance.Songs;
+        sounds = PrefabRepository.instance.Sounds;
 
 		PlayMusic(0);
 

--- a/Assets/Units/Models/PowerupManager.cs
+++ b/Assets/Units/Models/PowerupManager.cs
@@ -15,7 +15,7 @@ public class PowerupManager : MonoBehaviour {
         else
             Destroy(gameObject);
 
-        var objs = Resources.LoadAll<GameObject>("powerups");
+        var objs = PrefabRepository.instance.AllPowerups;
         foreach (var obj in objs)
             powerups.Add(obj.name, obj);
 

--- a/Assets/Weapons/EnemySpawner/EnemySpawnerGun.cs
+++ b/Assets/Weapons/EnemySpawner/EnemySpawnerGun.cs
@@ -11,7 +11,7 @@ public class EnemySpawnerGun : Weapon
 
     public EnemySpawnerGun(GameObject owner) : base(owner)
     {
-        AttackWeapon = Resources.Load<GameObject>("EnemySpawnerBullet");
+        AttackWeapon = PrefabRepository.instance.EnemySpawnerBullet;
         attackTimestamp = Time.time + cooldown;
         cooldown = 5;
         speed = 2f;

--- a/Assets/Weapons/Gun/Gun.cs
+++ b/Assets/Weapons/Gun/Gun.cs
@@ -9,7 +9,7 @@ class Gun : Weapon {
 
     public Gun(GameObject owner, float cd = 0.2f): base(owner)
 	{
-		AttackWeapon = Resources.Load<GameObject>("Bullet");
+        AttackWeapon = PrefabRepository.instance.Bullet;
 		attackTimestamp = -(cooldown + 1);
         cooldown = cd;
         speed = 4f;

--- a/Assets/Weapons/ImmolationGun/ImmolationGun.cs
+++ b/Assets/Weapons/ImmolationGun/ImmolationGun.cs
@@ -18,7 +18,7 @@ class ImmolationGun : Weapon
 
     public ImmolationGun(GameObject owner, float cd = 0.0f, int bulletLimit = 4, int maxN = 4, float lifetime = 4) : base(owner)
     {
-        AttackWeapon = Resources.Load<GameObject>("ImmolationBullet");
+        AttackWeapon = PrefabRepository.instance.ImmolationBullet;
         attackTimestamp = -(cooldown + 1);
         cooldown = cd;
         speed = 4f;

--- a/Assets/Weapons/Melee/MeleeGun.cs
+++ b/Assets/Weapons/Melee/MeleeGun.cs
@@ -12,7 +12,7 @@ public class MeleeGun : Weapon
 
     public MeleeGun(GameObject go) : base(go)
     {
-        AttackWeapon = Resources.Load<GameObject>("MeleeBullet");
+        AttackWeapon = PrefabRepository.instance.MeleeBullet;
         attackTimestamp = -(cooldown + 1);
         cooldown = 3f;
         speed = 4f;

--- a/Assets/Weapons/PlayerMelee/PlayerMeleeGun.cs
+++ b/Assets/Weapons/PlayerMelee/PlayerMeleeGun.cs
@@ -12,7 +12,7 @@ public class PlayerMeleeGun : Weapon
 
     public PlayerMeleeGun(GameObject go) : base(go)
     {
-        AttackWeapon = Resources.Load<GameObject>("PlayerMeleeBullet");
+        AttackWeapon = PrefabRepository.instance.PlayerMeleeBullet;
         attackTimestamp = -(cooldown + 1);
         cooldown = 0.5f;
         speed = 1f;

--- a/Assets/Weapons/ShieldGun/ShieldGun.cs
+++ b/Assets/Weapons/ShieldGun/ShieldGun.cs
@@ -15,7 +15,7 @@ class ShieldGun : Weapon
 
     public ShieldGun(GameObject owner, float cd = 0.2f, int bulletLimit = 4) : base(owner)
     {
-        AttackWeapon = Resources.Load<GameObject>("ShieldBullet");
+        AttackWeapon = PrefabRepository.instance.ShieldBullet;
         attackTimestamp = -(cooldown + 1);
         cooldown = cd;
         speed = 4f;

--- a/Assets/Weapons/SpecialGun/SpecialGun.cs
+++ b/Assets/Weapons/SpecialGun/SpecialGun.cs
@@ -10,7 +10,7 @@ class SpecialGun : Weapon
 
     public SpecialGun(GameObject owner, float cd = 0.2f): base (owner)
     {
-        AttackWeapon = Resources.Load<GameObject>("SpecialBullet");
+        AttackWeapon = PrefabRepository.instance.SpecialBullet;
         attackTimestamp= -(cooldown + 1);
         cooldown = cd;
         speed = 4f;


### PR DESCRIPTION
## Description
GitHub issue: #21 
So I read up a little bit on Resources.Load and Unity seems to discourage the use of it for these reasons: 

- Use of the Resources folder makes fine-grained memory management more difficult
- Improper use of Resources folders will increase application startup time and the length of builds
- As the number of Resources folders increases, management of the Assets within those folders becomes very difficult
- The Resources system degrades a project's ability to deliver custom content to specific platforms and eliminates the possibility of incremental content upgrades
- AssetBundle Variants are Unity's primary tool for adjusting content on a per-device basis

and good usages:

- Examples of this second case include MonoBehaviour singletons used to host prefabs

Which is what I've attempted here.

Source https://unity3d.com/learn/tutorials/topics/best-practices/resources-folder


## How to test / set up
1. Load any scene
2. Verify that it has ManagerManager (and that ManagerManager is still connected to the prefab so it has gotten the new PrefabRepositry)
3. Verify that things still seem to work as intended

## Code hygiene
- [ ] The code handles errors gracefully
- [x] The code doesn't contain unnecesary commented out code
- [x] The code doesn't contain spamming/forgotten/unclear Debug.Log()s
- [x] The code is properly formatted
